### PR TITLE
elixir-nodejs: make base elixir version a build arg

### DIFF
--- a/containers/elixir-nodejs/Dockerfile
+++ b/containers/elixir-nodejs/Dockerfile
@@ -1,6 +1,7 @@
 ARG variant="-slim"
+ARG elixir_ver="1.18-otp-27"
 
-FROM elixir:1.18-otp-27$variant
+FROM elixir:$elixir_ver$variant
 
 ARG port=4000
 ARG mix_env=dev

--- a/containers/elixir-nodejs/README.md
+++ b/containers/elixir-nodejs/README.md
@@ -12,6 +12,10 @@
 
     docker buildx build --push --platform linux/arm64,linux/amd64 --build-arg node_ver=20.x --tag quay.io/vizlegalq/elixir-nodejs:1.17-node20-otp-27-slim .
 
+The base elixir version defaults to the one in the Dockerfile; override it to rebuild older tags (rebuilding with `--pull` also picks up the latest OTP patch, e.g. security/ssl fixes):
+
+    docker buildx build --push --pull --platform linux/arm64,linux/amd64 --build-arg elixir_ver=1.17-otp-27 --build-arg node_ver=20.x --tag quay.io/vizlegalq/elixir-nodejs:1.17-node20-otp-27-slim .
+
 
 ## Build MultiArch with Podman
 


### PR DESCRIPTION
Allows rebuilding older image tags from master with `--build-arg elixir_ver=... --pull`, picking up the latest OTP patch release (e.g. ssl fixes such as OTP-20232, fixed in OTP 27.3.4.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)